### PR TITLE
ci: skip lint on main push, add module cache, use go-version-file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,13 +9,16 @@ on:
 jobs:
   lint:
     name: Lint
+    # Only on PRs — lint already passed before anything lands in main
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
 
     - uses: actions/setup-go@v5
       with:
-        go-version: '1.24'
+        go-version-file: go.mod
+        cache: true
 
     - name: Run linter
       uses: golangci/golangci-lint-action@v6
@@ -31,10 +34,8 @@ jobs:
 
     - uses: actions/setup-go@v5
       with:
-        go-version: '1.24'
-
-    - name: Install dependencies
-      run: go mod download
+        go-version-file: go.mod
+        cache: true
 
     - name: Run tests
       run: go test ./...
@@ -42,13 +43,19 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    needs: [lint, test]
+    needs: [ lint, test ]
+    # lint is skipped on main push (result = 'skipped'), which is fine — treat as success
+    if: |
+      always() &&
+      needs.test.result == 'success' &&
+      (needs.lint.result == 'success' || needs.lint.result == 'skipped')
     steps:
     - uses: actions/checkout@v4
 
     - uses: actions/setup-go@v5
       with:
-        go-version: '1.24'
+        go-version-file: go.mod
+        cache: true
 
     - name: Build
       run: CGO_ENABLED=0 go build -ldflags="-s -w" -o hctf2 .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,8 @@ jobs:
 
     - uses: actions/setup-go@v5
       with:
-        go-version: '1.24'
+        go-version-file: go.mod
+        cache: true
 
     - name: Build binaries
       run: |


### PR DESCRIPTION
## Summary

**Faster, no security loss:**

| Event | Jobs |
|-------|------|
| PR | `lint` + `test` (parallel) → `build` → `smoke-test` |
| push to main | `test` → `build` → `smoke-test` (lint skipped — already passed on PR) |
| tag push | release workflow only |

**Changes:**
- `lint` job conditionally skips on `push` events via `if: github.event_name == 'pull_request'`
- `build` uses `always()` + explicit result checks so a skipped lint doesn't block it
- `cache: true` on all `setup-go` steps — Go module cache persists between runs (~20-30s saved per job)
- `go-version-file: go.mod` replaces hardcoded `'1.24'` — auto-follows version bumps
- Same changes applied to release workflow