### PR TITLE
docs(brand): expand hCTF2 to Heavens CTF 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# hCTF2
+# Heavens CTF 2 (hCTF2)
 
 ![hCTF2 logo](internal/views/static/logo.svg)
 
@@ -7,7 +7,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-purple.svg)](./LICENSE)
 [![Go](https://img.shields.io/badge/Go-1.24+-blue.svg)](https://go.dev)
 
-A self-hosted CTF (Capture The Flag) platform. Single binary, no dependencies, runs anywhere Go does.
+**Heavens CTF 2** (**hCTF2**) is a self-hosted CTF (Capture The Flag) platform. Single binary, no dependencies, runs anywhere Go does.
 
 ---
 

--- a/internal/views/templates/base.html
+++ b/internal/views/templates/base.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{{.Title}} - hCTF2</title>
+    <title>{{.Title}} - Heavens CTF 2</title>
     <link rel="stylesheet" href="/static/css/tailwind.css">
     <link rel="icon" type="image/svg+xml" href="/static/favicon.svg">
     <link rel="stylesheet" href="/static/css/custom.css">
@@ -40,7 +40,7 @@
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
             <div class="flex justify-between h-16">
                 <div class="flex">
-                    <a href="/" class="flex items-center px-2 text-xl font-bold text-blue-400">hCTF2</a>
+                    <a href="/" class="flex items-center px-2 text-xl font-bold text-blue-400">Heavens CTF 2</a>
                     <div class="hidden sm:ml-6 sm:flex sm:space-x-8">
                         <a href="/challenges" class="inline-flex items-center px-1 pt-1 text-sm font-medium text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white transition-colors">
                             Challenges
@@ -148,7 +148,7 @@
 
     <footer class="mt-auto border-t border-gray-200 dark:border-dark-border py-3 transition-colors duration-200">
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center text-sm text-gray-500 dark:text-gray-400">
-            <p>hCTF2 - A modern CTF platform with SQL-powered analytics</p>
+            <p>Heavens CTF 2 (hCTF2) — A modern CTF platform with SQL-powered analytics</p>
         </div>
     </footer>
     {{if .CustomCode}}


### PR DESCRIPTION
## Summary
- README title changed to `Heavens CTF 2 (hCTF2)` with full name in opening line
- Browser tab titles now read `<Page> - Heavens CTF 2`
- Nav logo now reads `Heavens CTF 2`
- Footer now reads `Heavens CTF 2 (hCTF2)`

## Test plan
- [ ] Browser tab shows `Heavens CTF 2` suffix
- [ ] Nav logo reads `Heavens CTF 2`