### PR TITLE
fix(analytics): restore Umami support missing from v0.8.0

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -67,6 +67,8 @@ var (
 	serveCORSOrigins      string
 	serveSubmitRateLimit  int
 	serveUploadDir        string
+	serveUmamiScriptURL   string
+	serveUmamiWebsiteID   string
 )
 
 var serveCmd = &cobra.Command{
@@ -96,6 +98,8 @@ func init() {
 	f.StringVar(&serveCORSOrigins, "cors-origins", getEnv("CORS_ORIGINS", ""), "Comma-separated list of allowed CORS origins (empty = same-origin only)")
 	f.IntVar(&serveSubmitRateLimit, "submission-rate-limit", 5, "Max flag submissions per minute per user (0 = unlimited)")
 	f.StringVar(&serveUploadDir, "upload-dir", "./uploads", "Directory for file uploads")
+	f.StringVar(&serveUmamiScriptURL, "umami-script-url", getEnv("UMAMI_SCRIPT_URL", ""), "Umami analytics script URL (e.g. https://umami.example.com/script.js)")
+	f.StringVar(&serveUmamiWebsiteID, "umami-website-id", getEnv("UMAMI_WEBSITE_ID", ""), "Umami analytics website ID")
 
 	rootCmd.AddCommand(serveCmd)
 }
@@ -134,10 +138,12 @@ type Server struct {
 	SettingsH      *handlers.SettingsHandler
 	ImportExportH  *handlers.ImportExportHandler
 	CompetitionH   *handlers.CompetitionHandler
-	Motd           string
-	SubmitLimiter  *ratelimit.Limiter
-	Storage        storage.Storage
-	ScoreRecorder  *scorerecorder.Recorder
+	Motd            string
+	SubmitLimiter   *ratelimit.Limiter
+	Storage         storage.Storage
+	ScoreRecorder   *scorerecorder.Recorder
+	UmamiScriptURL  string
+	UmamiWebsiteID  string
 }
 
 // customFileHandler wraps the file server to set proper content types for WASM and workers.
@@ -313,6 +319,8 @@ func runServe(_ *cobra.Command, _ []string) error {
 		ScoreRecorder:  recorder,
 		Motd:           serveMOTD,
 		Storage:        stor,
+		UmamiScriptURL: serveUmamiScriptURL,
+		UmamiWebsiteID: serveUmamiWebsiteID,
 	}
 
 	if serveSubmitRateLimit > 0 {
@@ -584,6 +592,12 @@ func createAdminUser(db *database.DB, emailAddr, password string) {
 
 // Template rendering helper
 func (s *Server) Render(w http.ResponseWriter, name string, data interface{}) {
+	if m, ok := data.(map[string]interface{}); ok {
+		if s.UmamiScriptURL != "" && s.UmamiWebsiteID != "" {
+			m["UmamiScriptURL"] = s.UmamiScriptURL
+			m["UmamiWebsiteID"] = s.UmamiWebsiteID
+		}
+	}
 	if err := s.Templates.ExecuteTemplate(w, name, data); err != nil {
 		log.Printf("Template error: %v", err)
 		http.Error(w, "Internal server error", http.StatusInternalServerError)

--- a/internal/views/templates/base.html
+++ b/internal/views/templates/base.html
@@ -38,6 +38,9 @@
             {{.CustomCode.HeadHTML | safeHTML}}
         {{end}}
     {{end}}
+    {{if and .UmamiScriptURL .UmamiWebsiteID}}
+    <script defer src="{{.UmamiScriptURL}}" data-website-id="{{.UmamiWebsiteID}}"></script>
+    {{end}}
 </head>
 <body class="min-h-screen flex flex-col bg-gray-50 dark:bg-[#0f172a] text-gray-900 dark:text-[#e2e8f0] transition-colors duration-200">
     <nav class="bg-white dark:bg-dark-surface border-b border-gray-200 dark:border-dark-border transition-colors duration-200">
@@ -161,5 +164,42 @@
         {{end}}
     {{end}}
     <script src="/static/js/focus-trap.js"></script>
+    {{if and .UmamiScriptURL .UmamiWebsiteID}}
+    <script>
+    // Custom Umami event tracking for CTF-specific interactions.
+    // Fires after Umami's script.js loads (deferred), so umami.track() is available.
+    document.addEventListener('htmx:afterRequest', function(e) {
+        if (typeof umami === 'undefined') return;
+        const url = e.detail.requestConfig && e.detail.requestConfig.path || '';
+        const ok  = e.detail.successful;
+
+        // Flag submission: POST /api/questions/{id}/submit
+        const submitMatch = url.match(/\/api\/questions\/([^/]+)\/submit/);
+        if (submitMatch) {
+            const responseText = e.detail.xhr && e.detail.xhr.responseText || '';
+            const correct = responseText.includes('Correct') || responseText.includes('correct');
+            umami.track('flag-submit', { correct: correct });
+            return;
+        }
+
+        // Hint unlock: POST /api/hints/{id}/unlock
+        if (url.match(/\/api\/hints\/[^/]+\/unlock/) && ok) {
+            umami.track('hint-unlock');
+            return;
+        }
+
+        // Team registration for competition: POST /api/competitions/{id}/register
+        if (url.match(/\/api\/competitions\/\d+\/register/) && ok) {
+            umami.track('competition-register');
+            return;
+        }
+    });
+
+    // SQL Playground query execution (fired by the playground's run button)
+    document.addEventListener('sql-playground-run', function() {
+        if (typeof umami !== 'undefined') umami.track('sql-playground-run');
+    });
+    </script>
+    {{end}}
 </body>
 </html>


### PR DESCRIPTION
## Summary
The Umami analytics implementation (`feat(analytics)` commit) was on an orphaned branch and never made it into the v0.8.0 release PR — same root cause as PR #8 and #9.

**What this restores:**
- `--umami-script-url` / `--umami-website-id` flags on `serve` command, reading from `UMAMI_SCRIPT_URL` / `UMAMI_WEBSITE_ID` env vars
- `Render()` auto-injects both into every template data map
- Umami `<script>` injected in `<head>` when both values are set
- CTF-specific event tracking: `flag-submit` (with correct/incorrect), `hint-unlock`, `competition-register`, `sql-playground-run`

## Test plan
- [ ] Set `UMAMI_SCRIPT_URL` and `UMAMI_WEBSITE_ID` env vars, start server, verify script tag appears in page source
- [ ] Submit a flag — `flag-submit` event appears in Umami
- [ ] Unlock a hint — `hint-unlock` event appears
- [ ] Server starts cleanly without Umami env vars set (analytics disabled)