### PR TITLE
feat(docker): make port configurable via PORT env var (default 8090)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,10 @@ COPY --from=builder /app/hctf /hctf
 COPY --from=builder --chown=1000:1000 /staging/data /data
 COPY --from=builder --chown=1000:1000 /staging/tmp /tmp
 
-EXPOSE 8090
+ARG PORT=8090
+ENV PORT=$PORT
+
+EXPOSE $PORT
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
     CMD ["/hctf", "healthcheck", "--port", "8090"]

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -5,14 +5,14 @@ services:
       dockerfile: Dockerfile
     container_name: hctf-dev
     ports:
-      - "8090:8090"
+      - "${PORT:-8090}:${PORT:-8090}"
     volumes:
       # Persist database
       - ./data:/data
     command:
       - serve
       - --port
-      - "8090"
+      - "${PORT:-8090}"
       - --db
       - /data/hctf.db
       - --dev
@@ -21,8 +21,9 @@ services:
       - --admin-password
       - changeme
     environment:
+      - PORT=${PORT:-8090}
       - JWT_SECRET=${JWT_SECRET:-dev-secret-change-me}
-      - BASE_URL=${BASE_URL:-http://localhost:8090}
+      - BASE_URL=${BASE_URL:-http://localhost:${PORT:-8090}}
       - SMTP_HOST=${SMTP_HOST:-}
       - SMTP_PORT=${SMTP_PORT:-587}
       - SMTP_FROM=${SMTP_FROM:-}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,14 +3,14 @@ services:
     image: ghcr.io/ajesus37/hctf:latest
     container_name: hctf
     ports:
-      - "8090:8090"
+      - "${PORT:-8090}:${PORT:-8090}"
     volumes:
       # Persist database
       - hctf-data:/data
     command:
       - serve
       - --port
-      - "8090"
+      - "${PORT:-8090}"
       - --db
       - /data/hctf.db
       # Uncomment to create admin user on first run
@@ -19,8 +19,9 @@ services:
       # - --admin-password
       # - changeme
     environment:
+      - PORT=${PORT:-8090}
       - JWT_SECRET=${JWT_SECRET:-}
-      - BASE_URL=${BASE_URL:-http://localhost:8090}
+      - BASE_URL=${BASE_URL:-http://localhost:${PORT:-8090}}
       - SMTP_HOST=${SMTP_HOST:-}
       - SMTP_PORT=${SMTP_PORT:-587}
       - SMTP_FROM=${SMTP_FROM:-}
@@ -31,7 +32,7 @@ services:
       - UMAMI_WEBSITE_ID=${UMAMI_WEBSITE_ID:-}
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "/hctf", "healthcheck", "--port", "8090"]
+      test: ["CMD", "/hctf", "healthcheck", "--port", "${PORT:-8090}"]
       interval: 30s
       timeout: 5s
       start_period: 10s

--- a/docker/demo/Dockerfile.demo
+++ b/docker/demo/Dockerfile.demo
@@ -26,10 +26,13 @@ COPY docker/demo/seed.sh /app/seed.sh
 RUN chmod +x /app/entrypoint.sh /app/seed.sh
 RUN mkdir -p /data
 
-EXPOSE 8090
+ARG PORT=8090
+ENV PORT=$PORT
+
+EXPOSE $PORT
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=3 \
-    CMD wget -qO- http://localhost:8090/healthz || exit 1
+    CMD wget -qO- http://localhost:${PORT}/healthz || exit 1
 
 ENTRYPOINT ["/sbin/tini", "--"]
 CMD ["/app/entrypoint.sh"]

--- a/docker/demo/docker-compose.yml
+++ b/docker/demo/docker-compose.yml
@@ -4,10 +4,12 @@ services:
       context: ../..
       dockerfile: docker/demo/Dockerfile.demo
     ports:
-      - "8090:8090"
+      - "${PORT:-8090}:${PORT:-8090}"
+    environment:
+      - PORT=${PORT:-8090}
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "wget", "-qO-", "http://localhost:8090/healthz"]
+      test: ["CMD", "wget", "-qO-", "http://localhost:${PORT:-8090}/healthz"]
       interval: 30s
       timeout: 5s
       start_period: 60s

--- a/docker/demo/entrypoint.sh
+++ b/docker/demo/entrypoint.sh
@@ -4,7 +4,7 @@ set -e
 DB=/data/hctf.db
 ADMIN_EMAIL="admin@demo.hctf"
 ADMIN_PASSWORD="Admin123!"
-PORT=8090
+PORT=${PORT:-8090}
 BASE_URL="http://localhost:${PORT}"
 RESET_MINUTES=30
 


### PR DESCRIPTION
## Summary
- Add `ARG PORT=8090` / `ENV PORT=$PORT` to `Dockerfile` and `Dockerfile.demo`
- All docker-compose files use `${PORT:-8090}` for port mappings, `command`, healthcheck tests, and `BASE_URL`
- `docker/demo/entrypoint.sh` reads `PORT` from environment, defaulting to `8090`

## Usage
```bash
PORT=9000 docker compose up -d
```

## Test plan
- [ ] Default deploy still works on port 8090 (no `PORT` env set)
- [ ] Custom port: `PORT=9000 docker compose up -d` binds to 9000

🤖 Generated with [Claude Code](https://claude.com/claude-code)